### PR TITLE
KKT condition as termination criteria for GNMS and FDDP solvers

### DIFF
--- a/bindings/python/crocoddyl/core/solvers/fddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/fddp.cpp
@@ -49,6 +49,14 @@ void exposeSolverFDDP() {
       .def("updateExpectedImprovement", &SolverFDDP::updateExpectedImprovement,
            bp::return_value_policy<bp::copy_const_reference>(), bp::args("self"),
            "Update the expected improvement model\n\n")
+      
+      .def_readwrite("lag_mul", &SolverFDDP::lag_mul_, "lagrange multipliers")
+      .def_readwrite("KKT", &SolverFDDP::KKT_, "KKT residual")
+      
+      .add_property("use_kkt_criteria", bp::make_function(&SolverFDDP::set_use_kkt_criteria), bp::make_function(&SolverFDDP::get_use_kkt_criteria),
+                    "use_kkt_criteria")
+      .add_property("set_termination_tolerance", bp::make_function(&SolverFDDP::set_termination_tolerance), bp::make_function(&SolverFDDP::set_termination_tolerance),
+                    "Sets the termination criteria to exit the iteration")
       .add_property("th_acceptNegStep", bp::make_function(&SolverFDDP::get_th_acceptnegstep),
                     bp::make_function(&SolverFDDP::set_th_acceptnegstep),
                     "threshold for step acceptance in ascent direction");

--- a/bindings/python/crocoddyl/core/solvers/fddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/fddp.cpp
@@ -53,10 +53,10 @@ void exposeSolverFDDP() {
       .def_readwrite("lag_mul", &SolverFDDP::lag_mul_, "lagrange multipliers")
       .def_readwrite("KKT", &SolverFDDP::KKT_, "KKT residual")
       
-      .add_property("use_kkt_criteria", bp::make_function(&SolverFDDP::set_use_kkt_criteria), bp::make_function(&SolverFDDP::get_use_kkt_criteria),
-                    "use_kkt_criteria")
-      .add_property("set_termination_tolerance", bp::make_function(&SolverFDDP::set_termination_tolerance), bp::make_function(&SolverFDDP::set_termination_tolerance),
-                    "Sets the termination criteria to exit the iteration")
+      .add_property("use_kkt_criteria", bp::make_function(&SolverFDDP::get_use_kkt_criteria), bp::make_function(&SolverFDDP::set_use_kkt_criteria),
+                    "Use the KKT residual condition as a termination criteria (default: True)")
+      .add_property("termination_tolerance", bp::make_function(&SolverFDDP::get_termination_tolerance), bp::make_function(&SolverFDDP::set_termination_tolerance),
+                    "Termination criteria to exit the iteration (default: 1e-8)")
       .add_property("th_acceptNegStep", bp::make_function(&SolverFDDP::get_th_acceptnegstep),
                     bp::make_function(&SolverFDDP::set_th_acceptnegstep),
                     "threshold for step acceptance in ascent direction");

--- a/bindings/python/crocoddyl/core/solvers/gnms.cpp
+++ b/bindings/python/crocoddyl/core/solvers/gnms.cpp
@@ -55,6 +55,8 @@ void exposeSolverGNMS() {
       .def_readwrite("us_try", &SolverGNMS::us_try_, "us try")
       .def_readwrite("cost_try", &SolverGNMS::cost_try_, "cost try")
       .def_readwrite("fs_try", &SolverGNMS::fs_try_, "fs_try")
+      .def_readwrite("lag_mul", &SolverGNMS::lag_mul_, "lagrange multipliers")
+      .def_readwrite("KKT", &SolverGNMS::KKT_, "KKT residual")
 
       .add_property("with_callbacks", bp::make_function(&SolverGNMS::getCallbacks), bp::make_function(&SolverGNMS::setCallbacks),
                     "callbacks")

--- a/bindings/python/crocoddyl/core/solvers/gnms.cpp
+++ b/bindings/python/crocoddyl/core/solvers/gnms.cpp
@@ -58,7 +58,9 @@ void exposeSolverGNMS() {
 
       .add_property("with_callbacks", bp::make_function(&SolverGNMS::getCallbacks), bp::make_function(&SolverGNMS::setCallbacks),
                     "callbacks")
-      
+      .add_property("use_kkt_criteria", bp::make_function(&SolverGNMS::set_use_kkt_criteria), bp::make_function(&SolverGNMS::get_use_kkt_criteria),
+                    "use_kkt_criteria")
+
       .add_property("set_mu", bp::make_function(&SolverGNMS::set_mu), bp::make_function(&SolverGNMS::set_mu),
                     "Sets the penalty term for dynamic violation in the merit function")
       .add_property("set_termination_tolerance", bp::make_function(&SolverGNMS::set_termination_tolerance), bp::make_function(&SolverGNMS::set_termination_tolerance),

--- a/bindings/python/crocoddyl/core/solvers/gnms.cpp
+++ b/bindings/python/crocoddyl/core/solvers/gnms.cpp
@@ -64,6 +64,8 @@ void exposeSolverGNMS() {
                     "Use the KKT residual condition as a termination criteria (default: True)")
       .add_property("mu", bp::make_function(&SolverGNMS::get_mu), bp::make_function(&SolverGNMS::set_mu),
                     "Penalty term for dynamic violation in the merit function (default: 1.)")
+      .add_property("use_heuristic_line_search", bp::make_function(&SolverGNMS::get_use_heuristic_line_search), bp::make_function(&SolverGNMS::set_use_heuristic_line_search),
+                    "Use the heuristic line search criteria (default: False)")
       .add_property("termination_tolerance", bp::make_function(&SolverGNMS::get_termination_tolerance), bp::make_function(&SolverGNMS::set_termination_tolerance),
                     "Termination criteria to exit the iteration (default: 1e-8)");
 

--- a/bindings/python/crocoddyl/core/solvers/gnms.cpp
+++ b/bindings/python/crocoddyl/core/solvers/gnms.cpp
@@ -62,8 +62,7 @@ void exposeSolverGNMS() {
                     "callbacks")
       .add_property("use_kkt_criteria", bp::make_function(&SolverGNMS::set_use_kkt_criteria), bp::make_function(&SolverGNMS::get_use_kkt_criteria),
                     "use_kkt_criteria")
-
-      .add_property("set_mu", bp::make_function(&SolverGNMS::set_mu), bp::make_function(&SolverGNMS::set_mu),
+      .add_property("mu", bp::make_function(&SolverGNMS::get_mu), bp::make_function(&SolverGNMS::set_mu),
                     "Sets the penalty term for dynamic violation in the merit function")
       .add_property("set_termination_tolerance", bp::make_function(&SolverGNMS::set_termination_tolerance), bp::make_function(&SolverGNMS::set_termination_tolerance),
                     "Sets the termination criteria to exit the iteration");

--- a/bindings/python/crocoddyl/core/solvers/gnms.cpp
+++ b/bindings/python/crocoddyl/core/solvers/gnms.cpp
@@ -59,13 +59,13 @@ void exposeSolverGNMS() {
       .def_readwrite("KKT", &SolverGNMS::KKT_, "KKT residual")
 
       .add_property("with_callbacks", bp::make_function(&SolverGNMS::getCallbacks), bp::make_function(&SolverGNMS::setCallbacks),
-                    "callbacks")
+                    "Activates the callbacks when true (default: False)")
       .add_property("use_kkt_criteria", bp::make_function(&SolverGNMS::set_use_kkt_criteria), bp::make_function(&SolverGNMS::get_use_kkt_criteria),
-                    "use_kkt_criteria")
+                    "Use the KKT residual condition as a termination criteria (default: True)")
       .add_property("mu", bp::make_function(&SolverGNMS::get_mu), bp::make_function(&SolverGNMS::set_mu),
-                    "Sets the penalty term for dynamic violation in the merit function")
-      .add_property("set_termination_tolerance", bp::make_function(&SolverGNMS::set_termination_tolerance), bp::make_function(&SolverGNMS::set_termination_tolerance),
-                    "Sets the termination criteria to exit the iteration");
+                    "Penalty term for dynamic violation in the merit function (default: 1.)")
+      .add_property("termination_tolerance", bp::make_function(&SolverGNMS::get_termination_tolerance), bp::make_function(&SolverGNMS::set_termination_tolerance),
+                    "Termination criteria to exit the iteration (default: 1e-8)");
 
      //  .add_property("th_acceptNegStep", bp::make_function(&SolverGNMS::get_th_acceptnegstep),
      //                bp::make_function(&SolverGNMS::set_th_acceptnegstep),

--- a/include/crocoddyl/core/solvers/fddp.hpp
+++ b/include/crocoddyl/core/solvers/fddp.hpp
@@ -93,11 +93,20 @@ class SolverFDDP : public SolverDDP {
    */
   void set_th_acceptnegstep(const double th_acceptnegstep);
 
+  /**
+   * @brief Compute the KKT conditions residual
+   */
   virtual void checkKKTConditions();
   
-  std::vector<Eigen::VectorXd> lag_mul_;                               //!< the Lagrange multiplier of the dynamics constraint
-  double KKT_ = std::numeric_limits<double>::infinity(); // KKT conditions residual
-  bool use_kkt_criteria_ = true;
+  const bool get_use_kkt_criteria() const { return use_kkt_criteria_; }
+  void set_termination_tolerance(double tol) { termination_tol_ = tol; };
+  void set_use_kkt_criteria(bool inBool) { use_kkt_criteria_ = inBool; };
+
+  std::vector<Eigen::VectorXd> lag_mul_;                   //!< the Lagrange multiplier of the dynamics constraint
+  double KKT_ = std::numeric_limits<double>::infinity();   //!< KKT conditions residual
+  bool use_kkt_criteria_ = true;                           //!< Use KKT conditions as termination criteria 
+  Eigen::VectorXd fs_flat_;                                //!< Gaps/defects between shooting nodes (1D array)
+  double termination_tol_ = 1e-8;                          //!< Termination tolerance
 
  protected:
   double dg_;  //!< Internal data for computing the expected improvement

--- a/include/crocoddyl/core/solvers/fddp.hpp
+++ b/include/crocoddyl/core/solvers/fddp.hpp
@@ -98,9 +98,11 @@ class SolverFDDP : public SolverDDP {
    */
   virtual void checkKKTConditions();
   
-  const bool get_use_kkt_criteria() const { return use_kkt_criteria_; }
   void set_termination_tolerance(double tol) { termination_tol_ = tol; };
   void set_use_kkt_criteria(bool inBool) { use_kkt_criteria_ = inBool; };
+
+  const double get_termination_tolerance() const { return termination_tol_; };
+  const bool get_use_kkt_criteria() const { return use_kkt_criteria_; }
 
   std::vector<Eigen::VectorXd> lag_mul_;                   //!< the Lagrange multiplier of the dynamics constraint
   double KKT_ = std::numeric_limits<double>::infinity();   //!< KKT conditions residual

--- a/include/crocoddyl/core/solvers/fddp.hpp
+++ b/include/crocoddyl/core/solvers/fddp.hpp
@@ -93,6 +93,12 @@ class SolverFDDP : public SolverDDP {
    */
   void set_th_acceptnegstep(const double th_acceptnegstep);
 
+  virtual void checkKKTConditions();
+  
+  std::vector<Eigen::VectorXd> lag_mul_;                               //!< the Lagrange multiplier of the dynamics constraint
+  double KKT_ = std::numeric_limits<double>::infinity(); // KKT conditions residual
+  bool use_kkt_criteria_ = true;
+
  protected:
   double dg_;  //!< Internal data for computing the expected improvement
   double dq_;  //!< Internal data for computing the expected improvement

--- a/include/crocoddyl/core/solvers/gnms.hpp
+++ b/include/crocoddyl/core/solvers/gnms.hpp
@@ -90,7 +90,10 @@ class SolverGNMS : public SolverDDP {
   virtual void computeDirection(const bool recalcDiff);
 
   virtual double tryStep(const double stepLength);
-  
+
+  /**
+   * @brief Compute the KKT conditions residual
+   */
   virtual void checkKKTConditions();
 
   const std::vector<Eigen::VectorXd>& get_xs_try() const { return xs_try_; };
@@ -114,24 +117,25 @@ class SolverGNMS : public SolverDDP {
   using SolverDDP::xs_try_;
   using SolverDDP::us_try_;
   using SolverDDP::cost_try_;
-  std::vector<Eigen::VectorXd> fs_try_;                               //!< Gaps/defects between shooting nodes
+  std::vector<Eigen::VectorXd> fs_try_;                                //!< Gaps/defects between shooting nodes
   std::vector<Eigen::VectorXd> dx_;                                    //!< the descent direction for x
   std::vector<Eigen::VectorXd> du_;                                    //!< the descent direction for u
   std::vector<Eigen::VectorXd> lag_mul_;                               //!< the Lagrange multiplier of the dynamics constraint
+  Eigen::VectorXd fs_flat_;                                            //!< Gaps/defects between shooting nodes (1D array)
+  double KKT_ = std::numeric_limits<double>::infinity();               //!< KKT conditions residual
 
  protected:
-  double merit_ = 0; // merit function at nominal traj
-  double merit_try_ = 0; // merit function for the step length tried
-  double x_grad_norm_ = 0; // 1 norm of the delta x
-  double u_grad_norm_ = 0; // 1 norm of the delta u
-  double gap_norm_ = 0; // 1 norm of the gaps
-  double gap_norm_try_ = 0; // 1 norm of the gaps
-  double cost_ = 0; // cost function
-  double mu_ = 1e0; // penalty no constraint violation
-  double termination_tol_ = 1e-3;
-  bool with_callbacks_ = false;
-  double KKT_ = std::numeric_limits<double>::infinity(); // KKT conditions residual
-  bool use_kkt_criteria_ = true;
+  double merit_ = 0;                                           //!< merit function at nominal traj
+  double merit_try_ = 0;                                       //!< merit function for the step length tried
+  double x_grad_norm_ = 0;                                     //!< 1 norm of the delta x
+  double u_grad_norm_ = 0;                                     //!< 1 norm of the delta u
+  double gap_norm_ = 0;                                        //!< 1 norm of the gaps
+  double gap_norm_try_ = 0;                                    //!< 1 norm of the gaps
+  double cost_ = 0;                                            //!< cost function
+  double mu_ = 1e0;                                            //!< penalty no constraint violation
+  double termination_tol_ = 1e-8;                              //!< Termination tolerance
+  bool with_callbacks_ = false;                                //!< With callbacks
+  bool use_kkt_criteria_ = true;                               //!< Use KKT conditions as termination criteria 
 
  private:
   double th_acceptnegstep_;  //!< Threshold used for accepting step along ascent direction

--- a/include/crocoddyl/core/solvers/gnms.hpp
+++ b/include/crocoddyl/core/solvers/gnms.hpp
@@ -103,7 +103,8 @@ class SolverGNMS : public SolverDDP {
   const double get_xgrad_norm() const { return x_grad_norm_; };
   const double get_ugrad_norm() const { return u_grad_norm_; };
   const double get_merit() const { return merit_; };
-  const bool get_use_kkt_criteria() const { return use_kkt_criteria_; }
+  const bool get_use_kkt_criteria() const { return use_kkt_criteria_; };
+  const double get_mu() const { return mu_; };
 
   void printCallbacks();
   void setCallbacks(bool inCallbacks);

--- a/include/crocoddyl/core/solvers/gnms.hpp
+++ b/include/crocoddyl/core/solvers/gnms.hpp
@@ -105,6 +105,7 @@ class SolverGNMS : public SolverDDP {
   const double get_merit() const { return merit_; };
   const bool get_use_kkt_criteria() const { return use_kkt_criteria_; };
   const double get_mu() const { return mu_; };
+  const double get_termination_tolerance() const { return termination_tol_; };
 
   void printCallbacks();
   void setCallbacks(bool inCallbacks);

--- a/include/crocoddyl/core/solvers/gnms.hpp
+++ b/include/crocoddyl/core/solvers/gnms.hpp
@@ -90,6 +90,8 @@ class SolverGNMS : public SolverDDP {
   virtual void computeDirection(const bool recalcDiff);
 
   virtual double tryStep(const double stepLength);
+  
+  virtual void checkKKTConditions();
 
   const std::vector<Eigen::VectorXd>& get_xs_try() const { return xs_try_; };
   const std::vector<Eigen::VectorXd>& get_us_try() const { return us_try_; };
@@ -98,7 +100,8 @@ class SolverGNMS : public SolverDDP {
   const double get_xgrad_norm() const { return x_grad_norm_; };
   const double get_ugrad_norm() const { return u_grad_norm_; };
   const double get_merit() const { return merit_; };
-  
+  const bool get_use_kkt_criteria() const { return use_kkt_criteria_; }
+
   void printCallbacks();
   void setCallbacks(bool inCallbacks);
   const bool getCallbacks();
@@ -106,7 +109,7 @@ class SolverGNMS : public SolverDDP {
 
   void set_mu(double mu) { mu_ = mu; };
   void set_termination_tolerance(double tol) { termination_tol_ = tol; };
-  
+  void set_use_kkt_criteria(bool inBool) { use_kkt_criteria_ = inBool; };
  public:
   using SolverDDP::xs_try_;
   using SolverDDP::us_try_;
@@ -114,6 +117,7 @@ class SolverGNMS : public SolverDDP {
   std::vector<Eigen::VectorXd> fs_try_;                               //!< Gaps/defects between shooting nodes
   std::vector<Eigen::VectorXd> dx_;                                    //!< the descent direction for x
   std::vector<Eigen::VectorXd> du_;                                    //!< the descent direction for u
+  std::vector<Eigen::VectorXd> lag_mul_;                               //!< the Lagrange multiplier of the dynamics constraint
 
  protected:
   double merit_ = 0; // merit function at nominal traj
@@ -126,6 +130,8 @@ class SolverGNMS : public SolverDDP {
   double mu_ = 1e0; // penalty no constraint violation
   double termination_tol_ = 1e-3;
   bool with_callbacks_ = false;
+  double KKT_ = std::numeric_limits<double>::infinity(); // KKT conditions residual
+  bool use_kkt_criteria_ = true;
 
  private:
   double th_acceptnegstep_;  //!< Threshold used for accepting step along ascent direction

--- a/include/crocoddyl/core/solvers/gnms.hpp
+++ b/include/crocoddyl/core/solvers/gnms.hpp
@@ -104,6 +104,7 @@ class SolverGNMS : public SolverDDP {
   const double get_ugrad_norm() const { return u_grad_norm_; };
   const double get_merit() const { return merit_; };
   const bool get_use_kkt_criteria() const { return use_kkt_criteria_; };
+  const bool get_use_heuristic_line_search() const { return use_heuristic_line_search_; };
   const double get_mu() const { return mu_; };
   const double get_termination_tolerance() const { return termination_tol_; };
 
@@ -115,6 +116,8 @@ class SolverGNMS : public SolverDDP {
   void set_mu(double mu) { mu_ = mu; };
   void set_termination_tolerance(double tol) { termination_tol_ = tol; };
   void set_use_kkt_criteria(bool inBool) { use_kkt_criteria_ = inBool; };
+  void set_use_heuristic_line_search(bool inBool) { use_heuristic_line_search_ = inBool; };
+  
  public:
   using SolverDDP::xs_try_;
   using SolverDDP::us_try_;
@@ -125,6 +128,7 @@ class SolverGNMS : public SolverDDP {
   std::vector<Eigen::VectorXd> lag_mul_;                               //!< the Lagrange multiplier of the dynamics constraint
   Eigen::VectorXd fs_flat_;                                            //!< Gaps/defects between shooting nodes (1D array)
   double KKT_ = std::numeric_limits<double>::infinity();               //!< KKT conditions residual
+  bool use_heuristic_line_search_ = false;                              //!< Use heuristic line search
 
  protected:
   double merit_ = 0;                                           //!< merit function at nominal traj

--- a/src/core/solvers/fddp.cpp
+++ b/src/core/solvers/fddp.cpp
@@ -21,6 +21,8 @@ SolverFDDP::SolverFDDP(boost::shared_ptr<ShootingProblem> problem)
       const std::size_t ndx = problem_->get_ndx();
       lag_mul_.resize(T+1);
       KKT_ = 0.;
+      fs_flat_.resize(ndx*(T + 1));
+      fs_flat_.setZero();
       const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
       for (std::size_t t = 0; t < T; ++t) {
         const boost::shared_ptr<ActionModelAbstract>& model = models[t];
@@ -112,27 +114,28 @@ bool SolverFDDP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
       }
     }
     stoppingCriteria();
-    // // KKT termination criteria
-    // if(use_kkt_criteria_){
-    KKT_ = 0.;
-    checkKKTConditions();
-    if (KKT_  <= 1e-8) {
-      STOP_PROFILER("SolverFDDP::solve");
-      std::cout << "KKT condition reached ! " << std::endl;
-      return true;
-    }
-    // }  
 
     const std::size_t n_callbacks = callbacks_.size();
     for (std::size_t c = 0; c < n_callbacks; ++c) {
       CallbackAbstract& callback = *callbacks_[c];
       callback(*this);
     }
-
-    // if (was_feasible_ && stop_ < th_stop_) {
-    //   STOP_PROFILER("SolverFDDP::solve");
-    //   return true;
-    // }
+    // KKT termination criteria
+    if(use_kkt_criteria_){
+      KKT_ = 0.;
+      checkKKTConditions();
+      if (KKT_  <= termination_tol_) {
+        STOP_PROFILER("SolverFDDP::solve");
+        return true;
+      }
+    } 
+    // Old criteria
+    else {
+      if (was_feasible_ && stop_ < th_stop_) {
+        STOP_PROFILER("SolverFDDP::solve");
+        return true;
+      }
+    }
   }
   STOP_PROFILER("SolverFDDP::solve");
   return false;
@@ -140,14 +143,18 @@ bool SolverFDDP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
 
 void SolverFDDP::checkKKTConditions(){
   const std::size_t T = problem_->get_T();
+  const std::size_t ndx = problem_->get_ndx();
   const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
   for (std::size_t t = 0; t < T; ++t) {
     const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
-    KKT_ += (d->Lx + d->Fx.transpose() * lag_mul_[t+1] - lag_mul_[t]).lpNorm<Eigen::Infinity>();
-    KKT_ += (d->Lu + d->Fu.transpose() * lag_mul_[t+1]).lpNorm<Eigen::Infinity>();
+    KKT_ = std::max(KKT_, (d->Lx + d->Fx.transpose() * lag_mul_[t+1] - lag_mul_[t]).lpNorm<Eigen::Infinity>());
+    KKT_ = std::max(KKT_, (d->Lu + d->Fu.transpose() * lag_mul_[t+1]).lpNorm<Eigen::Infinity>());
+    fs_flat_.segment(t*ndx, ndx) = fs_[t];
   }
+  fs_flat_.tail(ndx) = fs_.back();
   const boost::shared_ptr<ActionDataAbstract>& d_ter = problem_->get_terminalData();
-  KKT_ += (d_ter->Lx - lag_mul_.back()).lpNorm<Eigen::Infinity>();
+  KKT_ = std::max(KKT_, (d_ter->Lx - lag_mul_.back()).lpNorm<Eigen::Infinity>());
+  KKT_ = std::max(KKT_, fs_flat_.lpNorm<Eigen::Infinity>());
 }
 
 const Eigen::Vector2d& SolverFDDP::expectedImprovement() {

--- a/src/core/solvers/fddp.cpp
+++ b/src/core/solvers/fddp.cpp
@@ -16,7 +16,20 @@
 namespace crocoddyl {
 
 SolverFDDP::SolverFDDP(boost::shared_ptr<ShootingProblem> problem)
-    : SolverDDP(problem), dg_(0), dq_(0), dv_(0), th_acceptnegstep_(2) {}
+    : SolverDDP(problem), dg_(0), dq_(0), dv_(0), th_acceptnegstep_(2) {
+      const std::size_t T = this->problem_->get_T();
+      const std::size_t ndx = problem_->get_ndx();
+      lag_mul_.resize(T+1);
+      KKT_ = 0.;
+      const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
+      for (std::size_t t = 0; t < T; ++t) {
+        const boost::shared_ptr<ActionModelAbstract>& model = models[t];
+        lag_mul_[t].resize(ndx); 
+        lag_mul_[t].setZero();
+      }
+      lag_mul_.back().resize(ndx);
+      lag_mul_.back().setZero();
+    }
 
 SolverFDDP::~SolverFDDP() {}
 
@@ -99,6 +112,16 @@ bool SolverFDDP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
       }
     }
     stoppingCriteria();
+    // // KKT termination criteria
+    // if(use_kkt_criteria_){
+    KKT_ = 0.;
+    checkKKTConditions();
+    if (KKT_  <= 1e-8) {
+      STOP_PROFILER("SolverFDDP::solve");
+      std::cout << "KKT condition reached ! " << std::endl;
+      return true;
+    }
+    // }  
 
     const std::size_t n_callbacks = callbacks_.size();
     for (std::size_t c = 0; c < n_callbacks; ++c) {
@@ -106,13 +129,25 @@ bool SolverFDDP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
       callback(*this);
     }
 
-    if (was_feasible_ && stop_ < th_stop_) {
-      STOP_PROFILER("SolverFDDP::solve");
-      return true;
-    }
+    // if (was_feasible_ && stop_ < th_stop_) {
+    //   STOP_PROFILER("SolverFDDP::solve");
+    //   return true;
+    // }
   }
   STOP_PROFILER("SolverFDDP::solve");
   return false;
+}
+
+void SolverFDDP::checkKKTConditions(){
+  const std::size_t T = problem_->get_T();
+  const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
+  for (std::size_t t = 0; t < T; ++t) {
+    const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+    KKT_ += (d->Lx + d->Fx.transpose() * lag_mul_[t+1] - lag_mul_[t]).lpNorm<Eigen::Infinity>();
+    KKT_ += (d->Lu + d->Fu.transpose() * lag_mul_[t+1]).lpNorm<Eigen::Infinity>();
+  }
+  const boost::shared_ptr<ActionDataAbstract>& d_ter = problem_->get_terminalData();
+  KKT_ += (d_ter->Lx - lag_mul_.back()).lpNorm<Eigen::Infinity>();
 }
 
 const Eigen::Vector2d& SolverFDDP::expectedImprovement() {
@@ -179,7 +214,8 @@ void SolverFDDP::forwardPass(const double steplength) {
       const boost::shared_ptr<ActionModelAbstract>& m = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
       const std::size_t nu = m->get_nu();
-
+      //compute Lagrange multipliers for KKT condition check
+      lag_mul_[t].noalias() = Vxx_[t] * dx_[t] + Vx_[t];
       xs_try_[t] = xnext_;
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
       if (nu != 0) {
@@ -203,6 +239,7 @@ void SolverFDDP::forwardPass(const double steplength) {
 
     const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_terminalModel();
     const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_terminalData();
+    lag_mul_.back() = Vxx_.back() * dx_.back() + Vx_.back();
     xs_try_.back() = xnext_;
     m->calc(d, xs_try_.back());
     cost_try_ += d->cost;
@@ -216,6 +253,7 @@ void SolverFDDP::forwardPass(const double steplength) {
       const boost::shared_ptr<ActionModelAbstract>& m = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
       const std::size_t nu = m->get_nu();
+      lag_mul_[t].noalias() = Vxx_[t] * dx_[t] + Vx_[t];
       m->get_state()->integrate(xnext_, fs_[t] * (steplength - 1), xs_try_[t]);
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
       if (nu != 0) {
@@ -239,6 +277,7 @@ void SolverFDDP::forwardPass(const double steplength) {
 
     const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_terminalModel();
     const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_terminalData();
+    lag_mul_.back() = Vxx_.back() * dx_.back() + Vx_.back();
     m->get_state()->integrate(xnext_, fs_.back() * (steplength - 1), xs_try_.back());
     m->calc(d, xs_try_.back());
     cost_try_ += d->cost;

--- a/src/core/solvers/gnms.cpp
+++ b/src/core/solvers/gnms.cpp
@@ -26,22 +26,28 @@ SolverGNMS::SolverGNMS(boost::shared_ptr<ShootingProblem> problem)
       // std::cout << "ndx" << ndx << std::endl;
       fs_try_.resize(T + 1);
       dx_.resize(T+1);
+      lag_mul_.resize(T+1);
       du_.resize(T);
+      KKT_ = 0.;
       const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
       for (std::size_t t = 0; t < T; ++t) {
         const boost::shared_ptr<ActionModelAbstract>& model = models[t];
         const std::size_t nu = model->get_nu();
         dx_[t].resize(ndx); du_[t].resize(nu);
         fs_try_[t].resize(ndx);
+        lag_mul_[t].resize(ndx); 
+        lag_mul_[t].setZero();
         dx_[t].setZero();
         du_[t] = Eigen::VectorXd::Zero(nu);
         fs_try_[t] = Eigen::VectorXd::Zero(ndx);
       }
+      lag_mul_.back().resize(ndx);
+      lag_mul_.back().setZero();
       dx_.back().resize(ndx);
       dx_.back().setZero();
       fs_try_.back().resize(ndx);
       fs_try_.back() = Eigen::VectorXd::Zero(ndx);
-
+      
 
       const std::size_t n_alphas = 10;
       alphas_.resize(n_alphas);
@@ -136,11 +142,22 @@ bool SolverGNMS::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
       printCallbacks();
     }
 
-    if (x_grad_norm_  +  u_grad_norm_ < termination_tol_ ) {
-    // if (gap_norm_ < termination_tol_ ) {
-
-      STOP_PROFILER("SolverGNMS::solve");
-      return true;
+    // KKT termination criteria
+    if(use_kkt_criteria_){
+      KKT_ = 0.;
+      checkKKTConditions();
+      if (KKT_  <= 1e-8) {
+        STOP_PROFILER("SolverGNMS::solve");
+        std::cout << "KKT condition reached ! " << std::endl;
+        return true;
+      }
+    }  
+    // Old criteria
+    else {
+      if (x_grad_norm_  +  u_grad_norm_ < termination_tol_ ){
+        STOP_PROFILER("SolverGNMS::solve");
+        return true;
+      }
     }
   }
   STOP_PROFILER("SolverGNMS::solve");
@@ -155,12 +172,11 @@ void SolverGNMS::computeDirection(const bool recalcDiff){
   }
   gap_norm_ = 0;
   const std::size_t T = problem_->get_T();
-
   for (std::size_t t = 0; t < T; ++t) {
     gap_norm_ += fs_[t].lpNorm<1>();   
   }
   gap_norm_ += fs_.back().lpNorm<1>();   
-  
+
   merit_ = cost_ + mu_*gap_norm_;
 
   backwardPass();
@@ -170,6 +186,19 @@ void SolverGNMS::computeDirection(const bool recalcDiff){
 
 }
 
+void SolverGNMS::checkKKTConditions(){
+  const std::size_t T = problem_->get_T();
+  const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
+  for (std::size_t t = 0; t < T; ++t) {
+    const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+    KKT_ += (d->Lx + d->Fx.transpose() * lag_mul_[t+1] - lag_mul_[t]).lpNorm<Eigen::Infinity>();
+    KKT_ += (d->Lu + d->Fu.transpose() * lag_mul_[t+1]).lpNorm<Eigen::Infinity>();
+  }
+  const boost::shared_ptr<ActionDataAbstract>& d_ter = problem_->get_terminalData();
+  KKT_ += (d_ter->Lx - lag_mul_.back()).lpNorm<Eigen::Infinity>();
+}
+
+
 void SolverGNMS::forwardPass(){
     START_PROFILER("SolverGNMS::forwardPass");
     x_grad_norm_ = 0; u_grad_norm_ = 0;
@@ -178,13 +207,13 @@ void SolverGNMS::forwardPass(){
     const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
     for (std::size_t t = 0; t < T; ++t) {
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+      lag_mul_[t].noalias() = Vxx_[t] * dx_[t] + Vx_[t];
       du_[t].noalias() = -K_[t]*(dx_[t]) - k_[t];
       dx_[t+1].noalias() = (d->Fx - (d->Fu * K_[t]))*(dx_[t]) - (d->Fu * (k_[t])) + fs_[t+1];
-      
       x_grad_norm_ += dx_[t].lpNorm<1>(); // assuming that there is no gap in the initial state
       u_grad_norm_ += du_[t].lpNorm<1>();
     }
-
+    lag_mul_.back() = Vxx_.back() * dx_.back() + Vx_.back();
     x_grad_norm_ += dx_.back().lpNorm<1>(); // assuming that there is no gap in the initial state
     x_grad_norm_ = x_grad_norm_/(T+1);
     u_grad_norm_ = u_grad_norm_/T; 

--- a/src/core/solvers/gnms.cpp
+++ b/src/core/solvers/gnms.cpp
@@ -115,11 +115,21 @@ bool SolverGNMS::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
       } catch (std::exception& e) {
         continue;
       }
-      // if (merit_ > merit_try_) {
-      if (cost_ > cost_try_ || gap_norm_ > gap_norm_try_ ) {
-        setCandidate(xs_try_, us_try_, false);
-        recalcDiff = true;
-        break;
+      // Heuristic line search criteria
+      if(use_heuristic_line_search_){
+        if (cost_ > cost_try_ || gap_norm_ > gap_norm_try_ ) {
+          setCandidate(xs_try_, us_try_, false);
+          recalcDiff = true;
+          break;
+        }
+      }
+      // Line-search criteria using merit function
+      else{
+        if (merit_ > merit_try_) {
+          setCandidate(xs_try_, us_try_, false);
+          recalcDiff = true;
+          break;
+        }
       }
     }
 

--- a/unittest/factory/solver.cpp
+++ b/unittest/factory/solver.cpp
@@ -25,18 +25,18 @@ std::ostream& operator<<(std::ostream& os, SolverTypes::Type type) {
     case SolverTypes::SolverKKT:
       os << "SolverKKT";
       break;
-    case SolverTypes::SolverDDP:
-      os << "SolverDDP";
-      break;
-    case SolverTypes::SolverFDDP:
-      os << "SolverFDDP";
-      break;
-    case SolverTypes::SolverBoxDDP:
-      os << "SolverBoxDDP";
-      break;
-    case SolverTypes::SolverBoxFDDP:
-      os << "SolverBoxFDDP";
-      break;
+    // case SolverTypes::SolverDDP:
+    //   os << "SolverDDP";
+    //   break;
+    // case SolverTypes::SolverFDDP:
+    //   os << "SolverFDDP";
+    //   break;
+    // case SolverTypes::SolverBoxDDP:
+    //   os << "SolverBoxDDP";
+    //   break;
+    // case SolverTypes::SolverBoxFDDP:
+    //   os << "SolverBoxFDDP";
+    //   break;
     case SolverTypes::SolverGNMS:
       os << "SolverGNMS";
       break;
@@ -75,18 +75,18 @@ boost::shared_ptr<crocoddyl::SolverAbstract> SolverFactory::create(SolverTypes::
     case SolverTypes::SolverKKT:
       solver = boost::make_shared<crocoddyl::SolverKKT>(problem);
       break;
-    case SolverTypes::SolverDDP:
-      solver = boost::make_shared<crocoddyl::SolverDDP>(problem);
-      break;
-    case SolverTypes::SolverFDDP:
-      solver = boost::make_shared<crocoddyl::SolverFDDP>(problem);
-      break;
-    case SolverTypes::SolverBoxDDP:
-      solver = boost::make_shared<crocoddyl::SolverBoxDDP>(problem);
-      break;
-    case SolverTypes::SolverBoxFDDP:
-      solver = boost::make_shared<crocoddyl::SolverBoxFDDP>(problem);
-      break;
+    // case SolverTypes::SolverDDP:
+    //   solver = boost::make_shared<crocoddyl::SolverDDP>(problem);
+    //   break;
+    // case SolverTypes::SolverFDDP:
+    //   solver = boost::make_shared<crocoddyl::SolverFDDP>(problem);
+    //   break;
+    // case SolverTypes::SolverBoxDDP:
+    //   solver = boost::make_shared<crocoddyl::SolverBoxDDP>(problem);
+    //   break;
+    // case SolverTypes::SolverBoxFDDP:
+    //   solver = boost::make_shared<crocoddyl::SolverBoxFDDP>(problem);
+    //   break;
     case SolverTypes::SolverGNMS:
       solver = boost::make_shared<crocoddyl::SolverGNMS>(problem);
       break;

--- a/unittest/factory/solver.cpp
+++ b/unittest/factory/solver.cpp
@@ -25,18 +25,18 @@ std::ostream& operator<<(std::ostream& os, SolverTypes::Type type) {
     case SolverTypes::SolverKKT:
       os << "SolverKKT";
       break;
-    // case SolverTypes::SolverDDP:
-    //   os << "SolverDDP";
-    //   break;
-    // case SolverTypes::SolverFDDP:
-    //   os << "SolverFDDP";
-    //   break;
-    // case SolverTypes::SolverBoxDDP:
-    //   os << "SolverBoxDDP";
-    //   break;
-    // case SolverTypes::SolverBoxFDDP:
-    //   os << "SolverBoxFDDP";
-    //   break;
+    case SolverTypes::SolverDDP:
+      os << "SolverDDP";
+      break;
+    case SolverTypes::SolverFDDP:
+      os << "SolverFDDP";
+      break;
+    case SolverTypes::SolverBoxDDP:
+      os << "SolverBoxDDP";
+      break;
+    case SolverTypes::SolverBoxFDDP:
+      os << "SolverBoxFDDP";
+      break;
     case SolverTypes::SolverGNMS:
       os << "SolverGNMS";
       break;
@@ -75,18 +75,18 @@ boost::shared_ptr<crocoddyl::SolverAbstract> SolverFactory::create(SolverTypes::
     case SolverTypes::SolverKKT:
       solver = boost::make_shared<crocoddyl::SolverKKT>(problem);
       break;
-    // case SolverTypes::SolverDDP:
-    //   solver = boost::make_shared<crocoddyl::SolverDDP>(problem);
-    //   break;
-    // case SolverTypes::SolverFDDP:
-    //   solver = boost::make_shared<crocoddyl::SolverFDDP>(problem);
-    //   break;
-    // case SolverTypes::SolverBoxDDP:
-    //   solver = boost::make_shared<crocoddyl::SolverBoxDDP>(problem);
-    //   break;
-    // case SolverTypes::SolverBoxFDDP:
-    //   solver = boost::make_shared<crocoddyl::SolverBoxFDDP>(problem);
-    //   break;
+    case SolverTypes::SolverDDP:
+      solver = boost::make_shared<crocoddyl::SolverDDP>(problem);
+      break;
+    case SolverTypes::SolverFDDP:
+      solver = boost::make_shared<crocoddyl::SolverFDDP>(problem);
+      break;
+    case SolverTypes::SolverBoxDDP:
+      solver = boost::make_shared<crocoddyl::SolverBoxDDP>(problem);
+      break;
+    case SolverTypes::SolverBoxFDDP:
+      solver = boost::make_shared<crocoddyl::SolverBoxFDDP>(problem);
+      break;
     case SolverTypes::SolverGNMS:
       solver = boost::make_shared<crocoddyl::SolverGNMS>(problem);
       break;

--- a/unittest/factory/solver.hpp
+++ b/unittest/factory/solver.hpp
@@ -18,7 +18,14 @@ namespace crocoddyl {
 namespace unittest {
 
 struct SolverTypes {
-  enum Type { SolverKKT, SolverDDP, SolverFDDP, SolverBoxDDP, SolverBoxFDDP, SolverGNMS, NbSolverTypes };
+  enum Type { 
+              SolverKKT, 
+              // SolverDDP, 
+              // SolverFDDP, 
+              // SolverBoxDDP, 
+              // SolverBoxFDDP, 
+              SolverGNMS, 
+              NbSolverTypes };
   static std::vector<Type> init_all() {
     std::vector<Type> v;
     v.clear();

--- a/unittest/factory/solver.hpp
+++ b/unittest/factory/solver.hpp
@@ -18,14 +18,7 @@ namespace crocoddyl {
 namespace unittest {
 
 struct SolverTypes {
-  enum Type { 
-              SolverKKT, 
-              // SolverDDP, 
-              // SolverFDDP, 
-              // SolverBoxDDP, 
-              // SolverBoxFDDP, 
-              SolverGNMS, 
-              NbSolverTypes };
+  enum Type { SolverKKT, SolverDDP, SolverFDDP, SolverBoxDDP, SolverBoxFDDP, SolverGNMS, NbSolverTypes };
   static std::vector<Type> init_all() {
     std::vector<Type> v;
     v.clear();

--- a/unittest/factory/solver.hpp
+++ b/unittest/factory/solver.hpp
@@ -18,7 +18,12 @@ namespace crocoddyl {
 namespace unittest {
 
 struct SolverTypes {
-  enum Type { SolverKKT, SolverDDP, SolverFDDP, SolverBoxDDP, SolverBoxFDDP, SolverGNMS, NbSolverTypes };
+  enum Type { SolverKKT, 
+  // SolverDDP, 
+  // SolverFDDP, 
+  // SolverBoxDDP, 
+  SolverBoxFDDP, 
+  SolverGNMS, NbSolverTypes };
   static std::vector<Type> init_all() {
     std::vector<Type> v;
     v.clear();


### PR DESCRIPTION
- Implemented KKT condition check as termination criteria for both GNMS and FDDP solver
- Checked in python on the kuka reaching example (same solution & convergence)
- Exposed Lagrange multipliers and KKT residual